### PR TITLE
Reusable session keys

### DIFF
--- a/src/actions/AccessControl.ts
+++ b/src/actions/AccessControl.ts
@@ -50,6 +50,15 @@ export const createSessionKeyTransactionParams = async (
             "https://docs.fun.xyz"
         )
     }
+    if (params.userId === undefined) {
+        throw new InvalidParameterError(
+            ErrorCode.MissingParameter,
+            "userId is required",
+            { params },
+            "Provide userId when creating a session key.",
+            "https://docs.fun.xyz"
+        )
+    }
     let { actionValueLimit, feeValueLimit } = params
     actionValueLimit ??= 0n
     feeValueLimit ??= 0n

--- a/src/actions/AccessControl.ts
+++ b/src/actions/AccessControl.ts
@@ -1,16 +1,41 @@
-import { Hex, getAddress, pad, padHex } from "viem"
+import { Hex, getAddress, pad } from "viem"
 import { AddOwnerParams, RemoveOwnerParams, RuleStruct, SessionKeyParams } from "./types"
 import { SessionKeyAuth } from "../auth"
+import { AuthInput } from "../auth/types"
 import { RBAC_CONTRACT_INTERFACE, TransactionParams } from "../common"
 import { EnvOption } from "../config"
 import { Chain } from "../data"
 import { Token } from "../data/Token"
 import { ErrorCode, InvalidParameterError } from "../errors"
-import { randomBytes } from "../utils"
 import { MerkleTree } from "../utils/MerkleUtils"
 import { getSigHash } from "../utils/ViemUtils"
 
-export const HashOne = padHex("0x1", { size: 32 })
+export const createFeeRecipientAndTokenMerkleTree = async (params: SessionKeyParams): Promise<MerkleTree> => {
+    if (params.feeRecipientWhitelist && params.feeTokenWhitelist) {
+        const recipients = params.feeRecipientWhitelist.map((recipient) => getAddress(recipient))
+        const tokens = await Promise.all(params.feeTokenWhitelist.map((token) => Token.getAddress(token)))
+        const feeRecipientAndTokenMerkleTree = new MerkleTree([...recipients, ...tokens])
+        return feeRecipientAndTokenMerkleTree
+    } else {
+        return new MerkleTree([])
+    }
+}
+
+export const createTargetSelectorMerkleTree = async (params: SessionKeyParams): Promise<MerkleTree> => {
+    const selectors: Hex[] = []
+    params.actionWhitelist.forEach((actionWhitelistItem) => {
+        if (typeof actionWhitelistItem === "string") {
+            selectors.push(actionWhitelistItem)
+        } else {
+            selectors.push(
+                ...actionWhitelistItem.functionWhitelist.map((functionName) => getSigHash(actionWhitelistItem.abi, functionName))
+            )
+        }
+    })
+    const targets = params.targetWhitelist.map((target) => getAddress(target))
+    const targetSelectorMerkleTree = new MerkleTree([...targets, ...selectors])
+    return targetSelectorMerkleTree
+}
 
 export const createSessionKeyTransactionParams = async (
     params: SessionKeyParams,
@@ -28,39 +53,18 @@ export const createSessionKeyTransactionParams = async (
     let { actionValueLimit, feeValueLimit } = params
     actionValueLimit ??= 0n
     feeValueLimit ??= 0n
-    const selectors: Hex[] = []
-    params.actionWhitelist.forEach((actionWhitelistItem) => {
-        if (typeof actionWhitelistItem === "string") {
-            selectors.push(actionWhitelistItem)
-        } else {
-            selectors.push(
-                ...actionWhitelistItem.functionWhitelist.map((functionName) => getSigHash(actionWhitelistItem.abi, functionName))
-            )
-        }
-    })
-    const targets = params.targetWhitelist.map((target) => getAddress(target))
-
-    let feeRecipientTokenMerkleRootHash = HashOne
-    if (params.feeRecipientWhitelist && params.feeTokenWhitelist) {
-        const recipients = params.feeRecipientWhitelist.map((recipient) => getAddress(recipient))
-        const tokens = await Promise.all(params.feeTokenWhitelist.map((token) => Token.getAddress(token)))
-        const feeRecipientAndTokenMerkleTree = new MerkleTree([...recipients, ...tokens])
-        feeRecipientTokenMerkleRootHash = feeRecipientAndTokenMerkleTree.getRoot()
-        params.user.setFeeRecipientMerkleTree(feeRecipientAndTokenMerkleTree)
-    }
-    const targetSelectorMerkleTree = new MerkleTree([...targets, ...selectors])
-    const targetSelectorMerkleRootHash = targetSelectorMerkleTree.getRoot()
-    params.user.setTargetSelectorMerkleTree(targetSelectorMerkleTree)
+    const targetSelectorMerkleTree = await createTargetSelectorMerkleTree(params)
+    const feeRecipientTokenMerkleTree = await createFeeRecipientAndTokenMerkleTree(params)
     const ruleStruct: RuleStruct = {
         deadline: convertTimestampToBigInt(params.deadline),
-        targetSelectorMerkleRootHash,
-        feeRecipientTokenMerkleRootHash,
+        targetSelectorMerkleRootHash: targetSelectorMerkleTree.getRootHash(),
+        feeRecipientTokenMerkleRootHash: feeRecipientTokenMerkleTree.getRootHash(),
         actionValueLimit,
         feeValueLimit
     }
-    const roleId = params.user.roleId
-    const ruleId = params.user.ruleId
-    const userid = await params.user.getUserId()
+    const roleId = params.roleId
+    const ruleId = params.ruleId
+    const userid = params.userId
 
     const setRuleCallData = RBAC_CONTRACT_INTERFACE.encodeData("setRule", [ruleId, ruleStruct])
     const connectRuleAndRoleCallData = RBAC_CONTRACT_INTERFACE.encodeData("addRuleToRole", [roleId, ruleId])
@@ -72,8 +76,10 @@ export const createSessionKeyTransactionParams = async (
     ])
 }
 
-export const createSessionUser = (): SessionKeyAuth => {
-    return new SessionKeyAuth({ privateKey: randomBytes(32) })
+export const createSessionUser = async (auth: AuthInput, params: SessionKeyParams): Promise<SessionKeyAuth> => {
+    const targetSelectorMerkleTree = await createTargetSelectorMerkleTree(params)
+    const feeRecipientAndTokenMerkleTree = await createFeeRecipientAndTokenMerkleTree(params)
+    return new SessionKeyAuth(auth, params.ruleId, params.roleId, targetSelectorMerkleTree, feeRecipientAndTokenMerkleTree)
 }
 
 export const addOwnerTxParams = async (

--- a/src/actions/AccessControl.ts
+++ b/src/actions/AccessControl.ts
@@ -73,11 +73,11 @@ export const createSessionKeyTransactionParams = async (
     }
     const roleId = params.roleId
     const ruleId = params.ruleId
-    const userid = params.userId
+    const userId = params.userId
 
     const setRuleCallData = RBAC_CONTRACT_INTERFACE.encodeData("setRule", [ruleId, ruleStruct])
     const connectRuleAndRoleCallData = RBAC_CONTRACT_INTERFACE.encodeData("addRuleToRole", [roleId, ruleId])
-    const connectUserToRoleCallData = RBAC_CONTRACT_INTERFACE.encodeData("addUserToRole", [roleId, userid])
+    const connectUserToRoleCallData = RBAC_CONTRACT_INTERFACE.encodeData("addUserToRole", [roleId, userId])
     const chain = await Chain.getChain({ chainIdentifier: txOptions.chain })
     const rbacAddress = await chain.getAddress("rbacAddress")
     return RBAC_CONTRACT_INTERFACE.encodeTransactionParams(rbacAddress, "multiCall", [

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,5 +1,4 @@
 import { Hex } from "viem"
-import { SessionKeyAuth } from "../auth"
 import { TransactionParams } from "../common"
 
 export interface ApproveAndExecParams {
@@ -84,7 +83,9 @@ export type SessionKeyParams = {
     deadline: number
     actionValueLimit?: bigint
     feeValueLimit?: bigint
-    user: SessionKeyAuth
+    ruleId: Hex // 32 bytes
+    roleId: Hex // 32 bytes
+    userId?: Hex // 32 bytes
 }
 
 export type ActionWhitelistObject = {

--- a/src/auth/SessionKeyAuth.ts
+++ b/src/auth/SessionKeyAuth.ts
@@ -25,14 +25,6 @@ export class SessionKeyAuth extends Auth {
         this.feeRecipientMerkleTree = feeRecipientMerkleTree
     }
 
-    async getRuleId(): Promise<Hex> {
-        return this.ruleId
-    }
-
-    async getRoleId(): Promise<Hex> {
-        return this.roleId
-    }
-
     override async signOp(operation: Operation, chain: Chain): Promise<Hex> {
         if (!this.targetSelectorMerkleTree) {
             throw new Error("SessionKeyAuth not connected to wallet")

--- a/src/auth/SessionKeyAuth.ts
+++ b/src/auth/SessionKeyAuth.ts
@@ -3,7 +3,6 @@ import { Auth } from "./Auth"
 import { AuthInput, WalletCallData } from "./types"
 import { ETH_TRANSFER_SELECTOR, WALLET_ABI } from "../common"
 import { Chain, Operation, WalletSignature, encodeWalletSignature } from "../data"
-import { randomBytes } from "../utils"
 import { MerkleTree } from "../utils/MerkleUtils"
 import { getSigHash } from "../utils/ViemUtils"
 
@@ -15,13 +14,15 @@ export class SessionKeyAuth extends Auth {
     ruleId: Hex
     roleId: Hex
 
-    targetSelectorMerkleTree?: MerkleTree
-    feeRecipientMerkleTree?: MerkleTree
+    targetSelectorMerkleTree: MerkleTree
+    feeRecipientMerkleTree: MerkleTree
 
-    constructor(authInput: AuthInput, ruleId: Hex = randomBytes(32), roleId: Hex = randomBytes(32)) {
+    constructor(authInput: AuthInput, ruleId: Hex, roleId: Hex, targetSelectorMerkleTree: MerkleTree, feeRecipientMerkleTree: MerkleTree) {
         super(authInput)
         this.ruleId = ruleId
         this.roleId = roleId
+        this.targetSelectorMerkleTree = targetSelectorMerkleTree
+        this.feeRecipientMerkleTree = feeRecipientMerkleTree
     }
 
     async getRuleId(): Promise<Hex> {
@@ -84,14 +85,6 @@ export class SessionKeyAuth extends Auth {
         } catch {
             throw new Error("Function or target is not allowed in session key")
         }
-    }
-
-    setTargetSelectorMerkleTree(targetSelectorMerkleTree: MerkleTree) {
-        this.targetSelectorMerkleTree = targetSelectorMerkleTree
-    }
-
-    setFeeRecipientMerkleTree(feeRecipientMerkleTree: MerkleTree) {
-        this.feeRecipientMerkleTree = feeRecipientMerkleTree
     }
 }
 

--- a/src/auth/SessionKeyAuth.ts
+++ b/src/auth/SessionKeyAuth.ts
@@ -18,10 +18,18 @@ export class SessionKeyAuth extends Auth {
     targetSelectorMerkleTree?: MerkleTree
     feeRecipientMerkleTree?: MerkleTree
 
-    constructor(authInput: AuthInput) {
+    constructor(authInput: AuthInput, ruleId: Hex = randomBytes(32), roleId: Hex = randomBytes(32)) {
         super(authInput)
-        this.ruleId = randomBytes(32)
-        this.roleId = randomBytes(32)
+        this.ruleId = ruleId
+        this.roleId = roleId
+    }
+
+    async getRuleId(): Promise<Hex> {
+        return this.ruleId
+    }
+
+    async getRoleId(): Promise<Hex> {
+        return this.roleId
     }
 
     override async signOp(operation: Operation, chain: Chain): Promise<Hex> {

--- a/src/utils/MerkleUtils.ts
+++ b/src/utils/MerkleUtils.ts
@@ -1,4 +1,4 @@
-import { Hex, concat, keccak256 } from "viem"
+import { Hex, concat, keccak256, padHex } from "viem"
 
 // Copied from contracts repo
 
@@ -74,6 +74,8 @@ export const verifyPath = (root: Hex, item: Hex, path: Hex[]) => {
     return hash === root
 }
 
+export const HashOne = padHex("0x1", { size: 32 })
+
 export class MerkleTree {
     tree: Hex[]
     constructor(list: Hex[]) {
@@ -83,9 +85,12 @@ export class MerkleTree {
         return getPathForItem(this.tree, item)
     }
     verifyPath(item: Hex, path: Hex[]) {
-        return verifyPath(this.getRoot(), item, path)
+        return verifyPath(this.getRootHash(), item, path)
     }
-    getRoot() {
+    getRootHash() {
+        if (this.tree.length === 0) {
+            return HashOne
+        }
         return this.tree[1]
     }
 }

--- a/src/utils/MerkleUtils.ts
+++ b/src/utils/MerkleUtils.ts
@@ -1,4 +1,5 @@
-import { Hex, concat, keccak256, padHex } from "viem"
+import { Hex, concat, keccak256 } from "viem"
+import { HashZero } from "../common"
 
 // Copied from contracts repo
 
@@ -74,8 +75,6 @@ export const verifyPath = (root: Hex, item: Hex, path: Hex[]) => {
     return hash === root
 }
 
-export const HashOne = padHex("0x1", { size: 32 })
-
 export class MerkleTree {
     tree: Hex[]
     constructor(list: Hex[]) {
@@ -89,7 +88,7 @@ export class MerkleTree {
     }
     getRootHash() {
         if (this.tree.length === 0) {
-            return HashOne
+            return HashZero
         }
         return this.tree[1]
     }

--- a/src/utils/MerkleUtils.ts
+++ b/src/utils/MerkleUtils.ts
@@ -1,5 +1,4 @@
-import { Hex, concat, keccak256 } from "viem"
-import { HashZero } from "../common"
+import { Hex, concat, keccak256, padHex } from "viem"
 
 // Copied from contracts repo
 
@@ -88,7 +87,7 @@ export class MerkleTree {
     }
     getRootHash() {
         if (this.tree.length === 0) {
-            return HashZero
+            return padHex("0x1", { size: 32 })
         }
         return this.tree[1]
     }

--- a/src/utils/WalletUtils.ts
+++ b/src/utils/WalletUtils.ts
@@ -16,6 +16,14 @@ export const generateRandomGroupId = (): Hex => {
     return generateRandomBytes32()
 }
 
+export const generateRoleId = (): Hex => {
+    return generateRandomBytes32()
+}
+
+export const generateRuleId = (): Hex => {
+    return generateRandomBytes32()
+}
+
 export const generateRandomNonceKey = (): bigint => {
     return BigInt(randomBytes(24))
 }

--- a/tests/testUtils/SessionKey.ts
+++ b/tests/testUtils/SessionKey.ts
@@ -5,7 +5,7 @@ import { Auth, SessionKeyAuth } from "../../src/auth"
 import { AddressZero, ERC20_ABI } from "../../src/common"
 import { GlobalEnvOption, configureEnvironment } from "../../src/config"
 import { Token } from "../../src/data"
-import { fundWallet, randomBytes } from "../../src/utils"
+import { fundWallet, generateRoleId, generateRuleId, randomBytes } from "../../src/utils"
 import { FunWallet } from "../../src/wallet"
 import { getAwsSecret, getTestApiKey } from "../getAWSSecrets"
 import "../../fetch-polyfill"
@@ -54,8 +54,8 @@ export const SessionKeyTest = (config: SessionKeyTestConfig) => {
         describe("With Session Key", () => {
             let user: SessionKeyAuth
             const sessionKeyPrivateKey = randomBytes(32)
-            const ruleId = randomBytes(32)
-            const roleId = randomBytes(32)
+            const ruleId = generateRuleId()
+            const roleId = generateRoleId()
             const minute = 60 * 1000
             let deadline
             let outtokenAddr

--- a/tests/testUtils/SessionKey.ts
+++ b/tests/testUtils/SessionKey.ts
@@ -130,7 +130,7 @@ export const SessionKeyTest = (config: SessionKeyTestConfig) => {
                     amount: randomApproveAmount,
                     token: outTokenAddress
                 })
-                console.log(await wallet.executeOperation(user, operation))
+                await wallet.executeOperation(user, operation)
                 await new Promise((resolve) => {
                     setTimeout(resolve, 5000)
                 })

--- a/tests/testUtils/SessionKey.ts
+++ b/tests/testUtils/SessionKey.ts
@@ -56,7 +56,7 @@ export const SessionKeyTest = (config: SessionKeyTestConfig) => {
 
         describe("With Session Key", () => {
             const sessionKeyPrivateKey = randomBytes(32)
-            const user = new SessionKeyAuth({ privateKey: sessionKeyPrivateKey })
+            const user = new SessionKeyAuth({ privateKey: sessionKeyPrivateKey }, )
             const second = 1000
             const minute = 60 * second
             let deadline
@@ -102,7 +102,7 @@ export const SessionKeyTest = (config: SessionKeyTestConfig) => {
             })
 
             it.only("use a regenerated session key with the same parameter", async () => {
-                const newuser = new SessionKeyAuth({ privateKey: sessionKeyPrivateKey }, await user.getRuleId(), await user.getRoleId())
+                const newuser = createSessionUser()
                 const basetokenAddr = await Token.getAddress(baseToken)
                 const outtokenAddr = await Token.getAddress(outToken)
                 const params: SessionKeyParams = {

--- a/tests/testUtils/Swap.ts
+++ b/tests/testUtils/Swap.ts
@@ -6,7 +6,7 @@ import { APPROVE_AND_SWAP_ABI, ERC20_CONTRACT_INTERFACE } from "../../src/common
 import { GlobalEnvOption, configureEnvironment } from "../../src/config"
 import { Chain, Token } from "../../src/data"
 import { InternalFailureError, InvalidParameterError } from "../../src/errors"
-import { fundWallet, isContract, randomBytes } from "../../src/utils"
+import { fundWallet, generateRoleId, generateRuleId, isContract, randomBytes } from "../../src/utils"
 import { FunWallet } from "../../src/wallet"
 import { getAwsSecret, getTestApiKey } from "../getAWSSecrets"
 import "../../fetch-polyfill"
@@ -126,8 +126,8 @@ export const SwapTest = (config: SwapTestConfig) => {
                         }
                     ],
                     deadline,
-                    ruleId: randomBytes(32),
-                    roleId: randomBytes(32)
+                    ruleId: generateRuleId(),
+                    roleId: generateRoleId()
                 }
                 user = await createSessionUser({ privateKey: randomBytes(32) }, sessionKeyParams)
                 sessionKeyParams.userId = await user.getUserId()

--- a/tests/testUtils/Swap.ts
+++ b/tests/testUtils/Swap.ts
@@ -1,16 +1,15 @@
 import { assert, expect } from "chai"
 import { Hex } from "viem"
 import { SessionKeyParams, createSessionUser } from "../../src/actions"
-import { Auth } from "../../src/auth"
+import { Auth, SessionKeyAuth } from "../../src/auth"
 import { APPROVE_AND_SWAP_ABI, ERC20_CONTRACT_INTERFACE } from "../../src/common"
 import { GlobalEnvOption, configureEnvironment } from "../../src/config"
 import { Chain, Token } from "../../src/data"
 import { InternalFailureError, InvalidParameterError } from "../../src/errors"
-import { fundWallet, isContract } from "../../src/utils"
+import { fundWallet, isContract, randomBytes } from "../../src/utils"
 import { FunWallet } from "../../src/wallet"
 import { getAwsSecret, getTestApiKey } from "../getAWSSecrets"
 import "../../fetch-polyfill"
-
 export interface SwapTestConfig {
     chainId: number
     inToken: string
@@ -111,7 +110,7 @@ export const SwapTest = (config: SwapTestConfig) => {
         })
 
         describe("With Session Key", () => {
-            const user = createSessionUser()
+            let user: SessionKeyAuth
             before(async () => {
                 const second = 1000
                 const minute = 60 * second
@@ -119,7 +118,6 @@ export const SwapTest = (config: SwapTestConfig) => {
                 const deadline = (Date.now() + 10 * minute) / 1000
                 const targetAddr = await chain.getAddress("tokenSwapAddress")
                 const sessionKeyParams: SessionKeyParams = {
-                    user,
                     targetWhitelist: [targetAddr],
                     actionWhitelist: [
                         {
@@ -127,14 +125,18 @@ export const SwapTest = (config: SwapTestConfig) => {
                             functionWhitelist: ["executeSwapETH", "executeSwapERC20"]
                         }
                     ],
-                    deadline
+                    deadline,
+                    ruleId: randomBytes(32),
+                    roleId: randomBytes(32)
                 }
+                user = await createSessionUser({ privateKey: randomBytes(32) }, sessionKeyParams)
+                sessionKeyParams.userId = await user.getUserId()
 
                 const operation = await wallet.createSessionKey(auth, await auth.getAddress(), sessionKeyParams)
                 await wallet.executeOperation(auth, operation)
             })
 
-            it("ETH => ERC20", async () => {
+            it.only("ETH => ERC20", async () => {
                 const walletAddress = await wallet.getAddress()
                 const tokenBalanceBefore = await Token.getBalanceBN(inToken, walletAddress)
 

--- a/tests/testUtils/Swap.ts
+++ b/tests/testUtils/Swap.ts
@@ -136,7 +136,7 @@ export const SwapTest = (config: SwapTestConfig) => {
                 await wallet.executeOperation(auth, operation)
             })
 
-            it.only("ETH => ERC20", async () => {
+            it("ETH => ERC20", async () => {
                 const walletAddress = await wallet.getAddress()
                 const tokenBalanceBefore = await Token.getBalanceBN(inToken, walletAddress)
 


### PR DESCRIPTION
Goal: Allow people to create a session key in one place and to reuse the session key in another place.

As long as users have the same auth, ruleId, roleId, targetSelectorMerkleTree, feeRecipientMerkleTree, they can reuse the session key auth