### PR TITLE
Save create new wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "test": "ts-mocha --exit tests/tenderly/*.ts --exit",
         "test-tenderly": "ts-mocha --exit tests/tenderly/*.ts",
         "test-aws": "env ts-mocha",
-        "test-goerli": "env ts-mocha --exit tests/goerli/*.ts",
+        "test-goerli": "env ts-mocha --exit tests/goerli/Wallet.ts",
         "local-test-tenderly": "env NODE_ENV=local ts-mocha --exit tests/tenderly/*.ts",
         "local-test-goerli": "env NODE_ENV=local ts-mocha --exit tests/goerli/*.ts",
         "staging-test-tenderly": "env NODE_ENV=staging ts-mocha --exit tests/tenderly/*.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "test": "ts-mocha --exit tests/tenderly/*.ts --exit",
         "test-tenderly": "ts-mocha --exit tests/tenderly/*.ts",
         "test-aws": "env ts-mocha",
-        "test-goerli": "env ts-mocha --exit tests/goerli/Wallet.ts",
+        "test-goerli": "env ts-mocha --exit tests/goerli/*.ts",
         "local-test-tenderly": "env NODE_ENV=local ts-mocha --exit tests/tenderly/*.ts",
         "local-test-goerli": "env NODE_ENV=local ts-mocha --exit tests/goerli/*.ts",
         "staging-test-tenderly": "env NODE_ENV=staging ts-mocha --exit tests/tenderly/*.ts",

--- a/src/wallet/FunWallet.ts
+++ b/src/wallet/FunWallet.ts
@@ -339,6 +339,25 @@ export class FunWallet extends FirstClassActions {
     }
 
     /**
+     * Saves the wallet to the authentication system.
+     * @param auth - The auth or signer to save the wallet to.
+     * @param txOptions - The configuration options.
+     * @returns A Promise that resolves when the wallet is saved to the authentication system.
+     */
+    async saveWalletToAuth(auth: Auth, txOptions: EnvOption = (globalThis as any).globalEnvOption): Promise<void> {
+        const chain = await Chain.getChain({ chainIdentifier: txOptions.chain })
+        const walletAddr = await this.getAddress()
+        const userId = await auth.getUserId()
+        const users = await auth.getUserIds(walletAddr, await chain.getChainId())
+        if (!users.includes(userId)) {
+            if (!(await checkWalletAccessInitialization(walletAddr))) {
+                await initializeWalletAccess(walletAddr, await auth.getAddress())
+            }
+            await addUserToWallet(auth.authId!, await chain.getChainId(), walletAddr, [userId], this.walletUniqueId)
+        }
+    }
+
+    /**
      * Generates an on-ramp URL for the account address.
      * @param {Address} address - The account address (optional, defaults to the wallet's address).
      * @returns {Promise<string>} The on-ramp URL.

--- a/src/wallet/FunWallet.ts
+++ b/src/wallet/FunWallet.ts
@@ -350,10 +350,10 @@ export class FunWallet extends FirstClassActions {
         const userId = await auth.getUserId()
         const users = await auth.getUserIds(walletAddr, await chain.getChainId())
         if (!users.includes(userId)) {
-            if (!(await checkWalletAccessInitialization(walletAddr))) {
+            if ((await checkWalletAccessInitialization(walletAddr)) === false) {
                 await initializeWalletAccess(walletAddr, await auth.getAddress())
             }
-            await addUserToWallet(auth.authId!, await chain.getChainId(), walletAddr, [userId], this.walletUniqueId)
+            await addUserToWallet(await auth.getAddress(), await chain.getChainId(), walletAddr, [userId], this.walletUniqueId)
         }
     }
 

--- a/src/wallet/FunWallet.ts
+++ b/src/wallet/FunWallet.ts
@@ -596,7 +596,13 @@ export class FunWallet extends FirstClassActions {
         }
         receipt = await getFullReceipt(operation.opId, chainId, receipt.userOpHash)
         if (isWalletInitOp(operation.userOp) && txOptions.skipDBAction !== true) {
-            await addUserToWallet(auth.authId!, chainId, await this.getAddress(), Array.from(this.userInfo!.keys()), this.walletUniqueId)
+            await addUserToWallet(
+                await auth.getAddress(),
+                chainId,
+                await this.getAddress(),
+                Array.from(this.userInfo!.keys()),
+                this.walletUniqueId
+            )
 
             if (txOptions?.gasSponsor?.sponsorAddress) {
                 const paymasterType = getPaymasterType(txOptions)

--- a/tests/goerli/Wallet.ts
+++ b/tests/goerli/Wallet.ts
@@ -1,0 +1,6 @@
+import { WalletTest, WalletTestConfig } from "../testUtils/Wallet"
+
+const config: WalletTestConfig = {
+    chainId: 5
+}
+WalletTest(config)

--- a/tests/testUtils/Wallet.ts
+++ b/tests/testUtils/Wallet.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai"
+import { Wallet } from "../../src/apis"
+import { Auth } from "../../src/auth"
+import { GlobalEnvOption, configureEnvironment } from "../../src/config"
+import { FunWallet } from "../../src/wallet"
+import { getAwsSecret, getTestApiKey } from "../getAWSSecrets"
+import "../../fetch-polyfill"
+
+export interface WalletTestConfig {
+    chainId: number
+}
+
+export const WalletTest = (config: WalletTestConfig) => {
+    const { chainId } = config
+    describe("funWallet", function () {
+        let auth: Auth
+
+        this.timeout(400_000)
+
+        before(async function () {
+            const apiKey = await getTestApiKey()
+            const options: GlobalEnvOption = {
+                chain: chainId,
+                apiKey: apiKey,
+                gasSponsor: {}
+            }
+            await configureEnvironment(options)
+
+            auth = new Auth({ privateKey: await getAwsSecret("PrivateKeys", "WALLET_PRIVATE_KEY") })
+        })
+
+        it("Wallet.SaveToAuth should not error", async () => {
+            const RandomNonce = Math.floor(Math.random() * 10000000000000)
+            const uniqueId = await auth.getWalletUniqueId(RandomNonce)
+            const funwallet = new FunWallet({
+                users: [{ userId: await auth.getAddress() }],
+                uniqueId
+            })
+            expect(funwallet.saveWalletToAuth(auth)).to.not.throw
+        })
+
+        it("Wallet.SaveToAuth auth should display new wallet", async () => {
+            const RandomNonce = Math.floor(Math.random() * 10000000000000)
+            const uniqueId = await auth.getWalletUniqueId(RandomNonce)
+            const funwallet = new FunWallet({
+                users: [{ userId: await auth.getAddress() }],
+                uniqueId
+            })
+            const account = await funwallet.getAddress()
+            await funwallet.saveWalletToAuth(auth)
+            const authWallets = await auth.getWallets()
+            expect(authWallets.find((wallet: Wallet) => wallet.walletAddr === account)).to.not.be.undefined
+        })
+    })
+}


### PR DESCRIPTION
New Core SDK function to support saving newly generated FunWallets to the database before a transaction has occured