### PR TITLE
[BAC-269] Fix BigInt Multiplication Issue in getMaxTxCost method

### DIFF
--- a/src/data/Operation.ts
+++ b/src/data/Operation.ts
@@ -67,9 +67,12 @@ export class Operation {
 
     getMaxTxCost(): bigint {
         const { maxFeePerGas, preVerificationGas, callGasLimit, verificationGasLimit } = this.userOp
-        const mul: number = this.userOp.paymasterAndData !== "0x" ? 3 : 1
-        const requiredGas = callGasLimit + verificationGasLimit * BigInt(mul) + preVerificationGas! ? preVerificationGas : 0n
-        return maxFeePerGas * requiredGas!
+
+        const mul: bigint = this.userOp.paymasterAndData !== "0x" ? 3n : 1n
+        const additionalGas = preVerificationGas ? preVerificationGas : 0n
+        const requiredGas: bigint = callGasLimit + verificationGasLimit * mul + additionalGas
+
+        return BigInt(maxFeePerGas) * requiredGas
     }
 
     async estimateGas(auth: Auth, userId: string, options: EnvOption = (globalThis as any).globalEnvOption): Promise<Operation> {


### PR DESCRIPTION
This PR addresses an issue where a type error was thrown during the multiplication of maxFeePerGas and requiredGas in the getMaxTxCost method.