### PR TITLE
✅Use proper naming convention

### DIFF
--- a/src/apis/TurnkeyApis.ts
+++ b/src/apis/TurnkeyApis.ts
@@ -3,12 +3,12 @@ import { API_URL } from "../common/constants"
 import { sendPostRequest } from "../utils/ApiUtils"
 
 export async function createTurnkeySubOrg(createSubOrgRequest: object): Promise<string> {
-    const res = await sendPostRequest(API_URL, "turnkey/createSubOrg", createSubOrgRequest)
+    const res = await sendPostRequest(API_URL, "turnkey/sub-org", createSubOrgRequest)
     return res
 }
 
 export async function createTurnkeyPrivateKey(signedRequest: object): Promise<TPrivateKeyState> {
-    const res = await sendPostRequest(API_URL, "turnkey/createPrivateKey", signedRequest)
+    const res = await sendPostRequest(API_URL, "turnkey/private-key", signedRequest)
     return {
         id: res.id,
         address: res.address


### PR DESCRIPTION
Use proper naming conventions for APIs